### PR TITLE
Bump up zstd-codec ver. in js/example package.json

### DIFF
--- a/js/example/package.json
+++ b/js/example/package.json
@@ -9,7 +9,7 @@
     "build": "browserify index.js -o dist/bundle.js -t babelify --presets es2015"
   },
   "dependencies": {
-    "zstd-codec": "^0.0.6"
+    "zstd-codec": "^0.0.9"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/js/example/yarn.lock
+++ b/js/example/yarn.lock
@@ -314,6 +314,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-zstd-codec@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.0.6.tgz#49969c7d20a002d627929c1af0d1c191d1329a2c"
+zstd-codec@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.0.9.tgz#995e23c2a5f374fd8a7af5838eb7b07fd05c5ecb"


### PR DESCRIPTION
### Why
The current example app doesn't work correctly because it refers to the old zstd-codec version(0.0.6). Therefore, the following error occurs;
```
Uncaught TypeError: streaming.decompressUsingDict is not a function
```

I just updated the **package.json** and **yarn.lock** files in order to work the example app correctly.