### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn add zstd-codec
 require module, and instantiate api objects.
 
 ```bash
-const ZstdCodec = require('zsztd-codec').ZstdCodec;
+const ZstdCodec = require('zstd-codec').ZstdCodec;
 ZstdCodec.run(zstd => {
     const simple = new zstd.Simple();
     const streaming = new zstd.Streaming();


### PR DESCRIPTION
This PR fixes a typo in the example, renaming `zsztd` with `zstd`.