### PR TITLE
Remove extra copy from `ArrayBufferHelper.transfer()`

### DIFF
--- a/js/lib/helpers.js
+++ b/js/lib/helpers.js
@@ -1,7 +1,7 @@
 class ArrayBufferHelper {
     static transfer(old_buffer, new_capacity) {
         const bytes = new Uint8Array(new ArrayBuffer(new_capacity));
-        bytes.set(new Uint8Array(old_buffer.slice(0, new_capacity)));
+        bytes.set(new Uint8Array(old_buffer, 0, Math.min(new_capacity, old_buffer.byteLength)));
         return bytes.buffer;
     }
 }


### PR DESCRIPTION
The `.slice()` function creates a copy of the original data, then `set()` does another copy. Instead, we can create a Uint8Array that uses `old_buffer` as its underlying buffer, and pass that into `set()`.

`Math.min()` is used because the Uint8Array constructor throws an error if the length is beyond the bounds of the buffer, while `slice()` silently ignored it.